### PR TITLE
Add async iterator 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 1.2.0
+* Add async iterator support for LevelDB and Iterator, use with `for await`
+
 ## 1.1.1
 * Fix iterators not return all values [#8](https://github.com/extremeheat/node-leveldb-zlib/issues/8), [#9](https://github.com/extremeheat/node-leveldb-zlib/pull/9)
 

--- a/binding.js
+++ b/binding.js
@@ -6,17 +6,17 @@ if (!process.versions.electron) {
   // Electron has its own crash handler, and segfault-handler
   // uses NAN which is a hassle, so only load outside electron
   try {
-    var SegfaultHandler = require('segfault-handler')
+    const SegfaultHandler = require('segfault-handler')
     SegfaultHandler.registerHandler('crash.log')
   } catch (e) {
     debug('[leveldb] segfault handler is not installed. If you run into crashing issues, install it with `npm i -D segfault-handler` to get debug info on native crashes')
   }
 }
 
-var bindings
-var pathToSearch = helper.getPath()
+let bindings
+const pathToSearch = helper.getPath()
 if (pathToSearch) {
-  var rpath = path.join(__dirname, pathToSearch, '/node-leveldb.node')
+  const rpath = path.join(__dirname, pathToSearch, '/node-leveldb.node')
   try {
     bindings = require(rpath)
   } catch (e) {

--- a/buildChecks.js
+++ b/buildChecks.js
@@ -14,7 +14,7 @@ function checkIfPrebuildExists () {
   }
 }
 
-var runCmake = true
+let runCmake = true
 
 if (!process.env.FORCE_BUILD) {
   if (checkIfPrebuildExists()) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,13 +8,10 @@ The keys and values can be either Buffers or Strings: strings will be converted 
   const db = new LevelDB(pathToDb, { createIfMissing: true })
   await db.open() // Make sure to wait for DB to open!
   await db.put('Hello', 'World')
-  const iter = db.getIterator({ values: true, keys: true }) // Both `keys` and `values` default to true
-  let entry
-  while (entry = await iter.next()) {
-    const [ val, key ] = entry.map(k => String(k))
+  for await (const [key, val] = await db.getIterator({ keyAsBuffer: false, valueAsBuffer: false })) {
     console.log('Read', key, val)
   }
-  await db.close() // Make sure to save and close when you're done!  
+  await db.close() // Make sure to save and close when you're done!
 ```
 
 See [example.js](./example.js) for an simple example program.

--- a/docs/example.js
+++ b/docs/example.js
@@ -12,10 +12,7 @@ async function basicTest (pathToDb) {
 async function iterate (pathToDb) {
   const db = new LevelDB(pathToDb)
   await db.open() // Make sure to wait for DB to open!
-  const iter = db.getIterator({ values: true, keys: true }) // Both `keys` and `values` default to true
-  let entry
-  while (entry = await iter.next()) {
-    const [val, key] = entry.map(k => String(k))
+  for await (const [key, val] of db.getIterator({ keyAsBuffer: false, valueAsBuffer: false })) {
     console.log('Read', key, val)
   }
   await db.close() // Make sure to save and close when you're done!

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc",
     "postci": "node helpers/postCI.js",
     "prepublish": "cd helpers && node npmPublish.js",
+    "fix": "ts-standard --fix",
     "test": "npm run build && mocha"
   },
   "author": "extremeheat",
@@ -18,20 +19,19 @@
     "type": "git",
     "url": "git://github.com/extremeheat/node-leveldb-zlib.git"
   },
-  "devDependencies": {
-    "@types/node": "^14.14.16",
-    "leveldb-zlib": "file:.",
-    "segfault-handler": "^1.3.0",
-    "ts-node": "^9.1.1",
-    "ts-standard": "^10.0.0",
-    "typescript": "^4.1.3"
-  },
   "dependencies": {
     "bindings": "^1.5.0",
     "cmake-js": "^6.1.0",
     "debug": "^4.3.1",
-    "mocha": "^8.4.0",
     "node-addon-api": "^3.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^14.14.16",
+    "leveldb-zlib": "file:.",
+    "ts-node": "^9.1.1",
+    "ts-standard": "^10.0.0",
+    "typescript": "^4.1.3",
+    "mocha": "^8.4.0"
   },
   "binary": {
     "napi_versions": [

--- a/test/extra.test.js
+++ b/test/extra.test.js
@@ -102,4 +102,29 @@ it('can iterate the db', async function () {
     assert.ok(val === 'Value')
   }
   assert.strictEqual(i, 3)
+  await db.close()
+})
+
+it('can iterate with asyncIterator', async function () {
+  try { fs.rmSync('./db', { recursive: true }) } catch {}
+  const db = new LevelDB('./db', { createIfMissing: true })
+  await db.open()
+  const keys = ['Key1', 'Key2', 'Key3']
+
+  for (const key of keys) {
+    await db.put(key, 'Value')
+  }
+
+  for await (const [key, val] of db) {
+    continue
+  }
+
+  let i = 0
+  for await (const [key, val] of db.getIterator({ keyAsBuffer: false, valueAsBuffer: false })) {
+    assert.strictEqual(key, keys[i++])
+    assert.strictEqual(val, 'Value')
+  }
+
+  assert.strictEqual(i, 3)
+  await db.close()
 })

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -12,7 +12,7 @@ it('create and write new db', async () => {
   await db.put('Hello', 'World!')
   await db.put('I', 'Like')
   const f32a = new Float32Array(10)
-  for (var i = 0; i < 10; i++) {
+  for (let i = 0; i < 10; i++) {
     f32a[i] = (3.14159 * Math.random())
   }
   await db.put('Pi', Buffer.from(f32a.buffer))
@@ -55,7 +55,7 @@ it('random read/write x10', async function () {
   }
 
   const promises = []
-  for (var i = 0; i < 10; i++) {
+  for (let i = 0; i < 10; i++) {
     promises.push(runTest(i, i % 2 === 0))
   }
   await Promise.all(promises)
@@ -65,7 +65,7 @@ it('random read/write x10', async function () {
 it('minecraft', async () => {
   const path = join(__dirname, './mctestdb')
 
-  var Tag = {}
+  const Tag = {}
   Tag[Tag.VersionNew = 44] = 'VersionNew'
   Tag[Tag.Data2D = 45] = 'Data2D'
   Tag[Tag.Data2DLegacy = 46] = 'Data2DLegacy'

--- a/ts/iterator.ts
+++ b/ts/iterator.ts
@@ -43,7 +43,7 @@ export class Iterator {
     if (this.finished) return null
     await (this.#lock = this._next())
     this.#lock = null
-    return this.cache.length ? this.cache.splice(-2, 2) : null
+    return (this.cache.length > 0) ? this.cache.splice(-2, 2) : null
   }
 
   async end () {
@@ -51,6 +51,15 @@ export class Iterator {
       delete this.cache
       binding.iterator_end(this.context, err => err ? rej(err) : res(true))
     })
+  }
+
+  async * [Symbol.asyncIterator] () {
+    let next
+    while (next = await this.next()) {
+      const [value, key] = next
+      yield [key, value]
+    }
+    this.end()
   }
 
   //
@@ -62,12 +71,12 @@ export class Iterator {
   }
 
   static cleanRangeOptions (options) {
-    var result = {}
+    const result = {}
 
-    for (var k in options) {
+    for (const k in options) {
       if (!Object.prototype.hasOwnProperty.call(options, k)) continue
 
-      var opt = options[k]
+      let opt = options[k]
 
       if (this.isRangeOption(k)) {
         // Note that we don't reject nullish and empty options here. While

--- a/ts/leveldb.ts
+++ b/ts/leveldb.ts
@@ -208,6 +208,15 @@ export class LevelDB {
     return new Iterator(this, options)
   }
 
+  async * [Symbol.asyncIterator] () {
+    const it = this.getIterator()
+    let next
+    while (next = await it.next()) {
+      const [value, key] = next
+      yield [key, value]
+    }
+  }
+
   /**
    * Delete all entries or a range.
    */


### PR DESCRIPTION
* Add async iterator support for LevelDB and Iterator, use with `for await`

```js
  for await (const [key, val] = await db.getIterator({ keyAsBuffer: false, valueAsBuffer: false })) {
    // ... to get key and val as a string
  }
```